### PR TITLE
BPI-845 changing github runners from standard to 8 core machines

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -56,7 +56,7 @@ jobs:
           path: coverage/
   migration-check:
     name: check for migration files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04-8core
     timeout-minutes: 10
     steps:
       # Checkout code


### PR DESCRIPTION
ubuntu-20.04-8core

current: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
trying: https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners